### PR TITLE
updated scanner to check links that do not have hrefs

### DIFF
--- a/Tools/scanner/linkcheck.js
+++ b/Tools/scanner/linkcheck.js
@@ -1,0 +1,3 @@
+    identifier: {
+      regex: new RegExp("usa-identifier"),
+      regex: new RegExp(

--- a/Tools/scanner/linkcheck.js
+++ b/Tools/scanner/linkcheck.js
@@ -1,3 +1,0 @@
-    identifier: {
-      regex: new RegExp("usa-identifier"),
-      regex: new RegExp(

--- a/Tools/scanner/package.json
+++ b/Tools/scanner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scanner",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This is a costly operation time and cpu-wise but wasn't sure about other ways to address it since the "links" have click handlers rather than using hrefs. This issue is primarily seen on our Salesforce hosted sites like labs.gsa.gov where the navigation takes place behind the scenes.