### PR TITLE
#432, updated identifierCustomPrivacy to be type:other so as to avoid…

### DIFF
--- a/Tools/scanner/src/scanner.js
+++ b/Tools/scanner/src/scanner.js
@@ -166,7 +166,7 @@ const itPerfMetricReport = async function (browser, url) {
     },
     identifierCustomPrivacy: {
       regex: /<a.*?>(Privacy Policy|Privacy).*?<\/a>/i,
-      type: "link",
+      type: "other",
       titleRegex: "customPrivacy",
     },
     identifierAccessibility: {


### PR DESCRIPTION
… the deep link checking that would otherwise take place.