### PR TITLE
Fix design consult deploy

### DIFF
--- a/.github/workflows/design-consults-deploy.yml
+++ b/.github/workflows/design-consults-deploy.yml
@@ -2,8 +2,10 @@ name: Design Consults Deploy
 
 on:
   push:
-    branches: [main]
-    paths: [design-consults]
+    branches:
+      - main
+    paths:
+      - 'design-consults/**'
   # Allows you to run this workflow manually from the Actions tab on GitHub.
   workflow_dispatch:
 

--- a/design-consults/src/pages/charts/index.astro
+++ b/design-consults/src/pages/charts/index.astro
@@ -209,7 +209,7 @@ const cssClass = "";
             // update css vars
             if (Object.prototype.hasOwnProperty.call(dataAttributesList, item)) {
                 for (const point in dataPoints) {
-                    const selector = document.querySelector(`#site-${item} .${dataPoints[point].num}`)
+                    const selector: HTMLElement = document.querySelector(`#site-${item} .${dataPoints[point].num}`)
                     selector.style.setProperty(
                         `--value`, dataAttributesList[item].getAttribute(dataPoints[point].val))
                     selector.style.setProperty(


### PR DESCRIPTION
This PR:
* Quiets some build errors introduced in #525 (but leaves in "hints", that I would not expect to interrupt the build) [error logs here](https://github.com/GSA/EDX/runs/7633273169?check_suite_focus=true#step:5:79)
* Updates GH workflow so hopefully the deploy is kicked automatically when changes to `/design-consults` is pushed to `main` 

A more elegant way to quiet errors would be to configure `astro check` to allow unused locals (which I think is very reasonable for this project) but couldn't figure out who to do that with a quick glance. 

Another thing we could configure is run astro/type checking on PRs to catch build errors before they happen, but not sure it's a big deal. 