### PR TITLE
Fix design consult button links

### DIFF
--- a/design-consults/src/components/Consult.astro
+++ b/design-consults/src/components/Consult.astro
@@ -9,6 +9,7 @@ export interface Props {
 const { slug, currentView } = Astro.props as Props;
 
 let iframeSrc = `${BASE_URL}consult_assets/${slug}/${currentView}/index.html`;
+let viewBaseUrl = `${BASE_URL}design-consults/${slug}`;
 ---
 
 <h1>{slug}</h1>
@@ -17,7 +18,7 @@ let iframeSrc = `${BASE_URL}consult_assets/${slug}/${currentView}/index.html`;
   {VIEWS.map((view) => (
     <li class="usa-button-group__item">
       <a
-        href={view}
+        href={`${viewBaseUrl}/${view}`}
         class={`usa-button ${
           currentView === view ? "" : "usa-button--outline"
         }`}


### PR DESCRIPTION
Uses full paths for those btns.

Started a [quick spike](https://github.com/lilaconlee/EDX/tree/add-cypress) of what adding cypress tests to run before deploys might require, but stopped when I realized they wouldn't have caught this bug (was not able to recreate locally). Think it could be a good idea with the finicky combo of ghpages + astro, but still needs a little work. Happy to finish it if that seems valuable or leave it be. 