### PR TITLE
Adding new accessbility link to edxcli scan which is redirected to fr…

### DIFF
--- a/Tools/edxcli/src/helpers/websites/it-performance-metric.ts
+++ b/Tools/edxcli/src/helpers/websites/it-performance-metric.ts
@@ -28,7 +28,7 @@ export class ItPerfMetricReport implements ScanFacetInterface {
     },
     identifierAccessibility: {
       regex:
-        /website-information\/accessibility-aids|website-information\/website-policies|portal\/content\/116609/i,
+        /website-information\/accessibility-aids|website-information\/website-policies|portal\/content\/116609|website-information\/accessibility-statement/i,
       type: 'link',
     },
     identifierFOIA: {


### PR DESCRIPTION
…om the 'website-information/accessbility-aids' URL. I discovered this while scanning arm.fas.gsa.gov