### PR TITLE
Change the name within package.json to avoid confusion with the coincidentally named edx_cli npm library that snyk stated has malicious code

### DIFF
--- a/Tools/edxcli/README.md
+++ b/Tools/edxcli/README.md
@@ -111,11 +111,11 @@ GitHub Action Repository secrets share the same names as the keys in `.env`. As 
 
 <!-- usage -->
 ```sh-session
-$ npm install -g edx_cli
+$ npm install -g edxcli_gsa
 $ edxcli COMMAND
 running command...
 $ edxcli (--version)
-edx_cli/1.0.0 darwin-x64 node-v18.15.0
+edxcli_gsa/1.0.0 darwin-x64 node-v18.16.0
 $ edxcli --help [COMMAND]
 USAGE
   $ edxcli COMMAND

--- a/Tools/edxcli/package.json
+++ b/Tools/edxcli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "edx_cli",
+  "name": "edxcli_gsa",
   "description": "oclif based CLI to evaluate web properties",
   "version": "1.0.0",
   "author": "US General Services Administration",


### PR DESCRIPTION
Commit to change the name of the package.json file reference from edx_cli to edxcli_gsa to avoid any future confusion with the edx_cli npm inventory that had been coincidentally named the same thing (i.e. edx_cli) and noted by snyk to have malicious code.