### PR TITLE
Adding pbs-billing.gsa.gov's public-facing subpage 

### DIFF
--- a/Tools/edxcli/README.md
+++ b/Tools/edxcli/README.md
@@ -744,7 +744,7 @@ All scan contain a `scanVersion` attribute which ties back to the version number
 
 ## 0.0.20
 
-pbs-billing.gsa.gov has a public face via https://www.pbs-billing.gsa.gov/users/CheckIfUserExists.aspx, updating metadata to scan the public-page
+pbs-billing.gsa.gov has a public face via https://www.pbs-billing.gsa.gov/ROW/users/CheckIfUserExists.aspx, updating metadata to scan the public-page
 
 ## 0.0.19
 

--- a/Tools/edxcli/src/helpers/websites/websites-metadata.ts
+++ b/Tools/edxcli/src/helpers/websites/websites-metadata.ts
@@ -577,7 +577,7 @@ const data: Record<string, IWebsiteAttributes> = {
     notes: '',
     queryString: '',
     searchNotReq: false,
-    urlPath: '/users/CheckIfUserExists.aspx',
+    urlPath: 'ROW/users/CheckIfUserExists.aspx',
     wwwPrefix: 'www.',
   },
   'phdc-pub.gsa.gov': {


### PR DESCRIPTION
Adding pbs-billing.gsa.gov's public-facing subpage so that the edxcli scans the correct path and doesn't fail on the landing page